### PR TITLE
Added parameterized queries

### DIFF
--- a/test/cypher._coffee
+++ b/test/cypher._coffee
@@ -95,5 +95,18 @@ assert.equal results[0]['m.name'], user7.name
 assert.equal results[1]['m.name'], user8.name
 assert.equal results[2]['m.name'], user9.name
 
+parameterizedQueryResults = db.query """
+    START n=node({userId})
+    MATCH (n) -[r:follows]-> (m)
+    RETURN r, m.name
+""", userId: user6.id, _
+assert.equal results.length, 3
+assert.ok typeof results[0]['r'], 'object'
+assert.ok typeof results[0]['m.name'], 'string'
+assert.equal results[0]['r'].type, 'follows'
+assert.equal results[0]['m.name'], user7.name
+assert.equal results[1]['m.name'], user8.name
+assert.equal results[2]['m.name'], user9.name
+
 # give some confidence that these tests actually passed ;)
 console.log 'passed cypher tests'


### PR DESCRIPTION
You can now use db.query like this:

``` javascript
var pquery = ["START n=node({userId})",
  "MATCH (n) -[r:follows]-> (m)",
  "RETURN r, m.name"].join("\n");

db.query(pquery, { userId: 37 }, function(err, results) {
  // ...
});
```

The old way still works, though:

``` javascript
var query = ["START n=node(37)",
  "MATCH (n) -[r:follows]-> (m)",
  "RETURN r, m.name"].join("\n");

db.query(query, function(err, results) {
  // ...
});
```

_Addresses issue #24. -@aseemk_
