### PR TITLE
Fixing cypher tests #52

### DIFF
--- a/test/cypher._coffee
+++ b/test/cypher._coffee
@@ -90,8 +90,8 @@ results = db.query """
     ORDER BY m.name
 """, _
 assert.equal results.length, 3
-assert.ok typeof results[0]['r'], 'object'
-assert.ok typeof results[0]['m.name'], 'string'
+assert.equal typeof results[0]['r'], 'object'
+assert.equal typeof results[0]['m.name'], 'string'
 assert.equal results[0]['r'].type, 'follows'
 assert.equal results[0]['m.name'], user7.name
 assert.equal results[1]['m.name'], user8.name
@@ -105,8 +105,8 @@ results = db.query '''
     ORDER BY m.name
 ''', {userId: user3.id}, _
 assert.equal results.length, 3
-assert.ok typeof results[0]['r'], 'object'
-assert.ok typeof results[0]['m.name'], 'string'
+assert.equal typeof results[0]['r'], 'object'
+assert.equal typeof results[0]['m.name'], 'string'
 assert.equal results[0]['r'].type, 'follows'
 assert.equal results[0]['m.name'], user4.name
 assert.equal results[1]['m.name'], user5.name
@@ -119,7 +119,7 @@ results = db.query """
 """, _
 assert.equal results.length, 1
 assert.ok results[0]['collect(n)'] instanceof Array
-assert.ok typeof results[0]['collect(n)'][0], 'object'
+assert.equal typeof results[0]['collect(n)'][0], 'object'
 assert.equal results[0]['collect(n)'][0].id, user0.id
 assert.equal results[0]['collect(n)'][0].data.name, user0.name
 
@@ -130,9 +130,9 @@ results = db.query """
     RETURN path
 """, {fromId: user0.id, toId: user6.id}, _
 assert.equal results.length, 1
-assert.ok typeof results[0]['path'], 'object'
-assert.ok typeof results[0]['path'].start, 'object'
-assert.ok typeof results[0]['path'].end, 'object'
+assert.equal typeof results[0]['path'], 'object'
+assert.equal typeof results[0]['path'].start, 'object'
+assert.equal typeof results[0]['path'].end, 'object'
 assert.ok results[0]['path'].nodes instanceof Array
 assert.ok results[0]['path'].relationships instanceof Array
 assert.equal results[0]['path'].length, 2


### PR DESCRIPTION
This should fix the tests in #52.
- the nodes are sometimes returned out of order with the "concurrent create", so I added ORDER BY to solve those failures
- you were missing a comma in the array test, which is the failure stated in #52

Tested in 1.9-SNAPSHOT as well.

Sorry, labeled the commit with the wrong ticket number.
