### PR TITLE
Create node/relationship index with configuration

### DIFF
--- a/lib/GraphDatabase._coffee
+++ b/lib/GraphDatabase._coffee
@@ -428,15 +428,16 @@ module.exports = class GraphDatabase
     # Create node index.
     #
     # @param name {String}
+    # @param config {Object} Node index configuration
     # @param callback {Function}
     #
-    createNodeIndex: (name, _) ->
+    createNodeIndex: (name, config={}, _) ->
         try
             services = @getServices _
 
             response = @_request.post
                 url: services.node_index
-                json: {name}
+                json: {name, config}
             , _
 
             if response.statusCode isnt status.CREATED
@@ -511,15 +512,16 @@ module.exports = class GraphDatabase
     # Create relationship index.
     #
     # @param name {String}
+    # @param config {Object} Relationship index configuration
     # @param callback {Function}
     #
-    createRelationshipIndex: (name, _) ->
+    createRelationshipIndex: (name, config={}, _) ->
         try
             services = @getServices _
 
             response = @_request.post
                 url: "#{services.relationship_index}/"
-                json: {name}
+                json: {name, config}
             , _
 
             if response.statusCode isnt status.CREATED

--- a/test/crud._coffee
+++ b/test/crud._coffee
@@ -16,6 +16,10 @@ matData =
     name: 'Mat'
     name2: 'Matt'
     id: '12345'
+indexConfig = 
+    type: 'fulltext'
+    provider: 'lucene'
+    to_lower_case: 'false'
 
 # instances we're going to reuse across tests:
 daniel = null
@@ -55,7 +59,7 @@ relIndexName = 'testFollows'
             expect(relIndexes[name].type).to.be.a 'string'
 
     'createNodeIndex': (_) ->
-        db.createNodeIndex nodeIndexName, _
+        db.createNodeIndex nodeIndexName, indexConfig, _
 
         # our newly created index should now be in the list of indexes:
         nodeIndexes = db.getNodeIndexes _
@@ -63,7 +67,7 @@ relIndexName = 'testFollows'
         expect(nodeIndexes).to.contain.key nodeIndexName
 
     'createRelationshipIndex': (_) ->
-        db.createRelationshipIndex relIndexName, _
+        db.createRelationshipIndex relIndexName, indexConfig, _
 
         # our newly created index should now be in the list of indexes:
         relIndexes = db.getRelationshipIndexes _


### PR DESCRIPTION
Added a 2nd parameter to createNodeIndex and createRelationshipIndex
methods to accept a index configuration object.  If second parameter is
passed null or empty, an index with default configuration will be
created.  Corresponding tests are also added.
