### PR TITLE
Added type-checking for query arg in query function. query as {} kill neo4j-2.0.0RC1

### DIFF
--- a/lib/GraphDatabase._coffee
+++ b/lib/GraphDatabase._coffee
@@ -717,7 +717,7 @@ module.exports = class GraphDatabase
                 throw new Error 'Cypher plugin not installed'
 
             if typeof query isnt 'string'
-                throw new Error 'Query is expected to be a string, #{typeof query} given'
+                throw new Error 'Query is expected to be a string'
 
             response = @_request.post
                 uri: endpoint


### PR DESCRIPTION
Hi, 

A developer of ours accidentally passed a promise in place of the query string to db.query(). An error was returned as expected, except that this seems to cause some persistent internal failure to neo4j (unable to delete nodes, REST server misbehaving, queries not returning, etc - I'll bring this up with the neo4j folks) which would only be solved by restarting neo4j.

I think this is a fairly easy mistake to make, and the persistent side-effects made us add a type-check to the query function to ensure that the query arg is indeed a string. Perhaps this is useful to others as well.

Thanks, 

tasinet
