### PR TITLE
Include neo4j's original error in error objects

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -93,6 +93,9 @@ exports.adjustError = (error) ->
 
         error = new Error
         error.message = serverError.message or serverError
+        
+        # Attach original error to expose neo4j's error stack and code
+        error.originalError = serverError
 
     if typeof error isnt 'object'
         error = new Error error
@@ -102,7 +105,7 @@ exports.adjustError = (error) ->
     # see: http://stackoverflow.com/a/9254101/132978
     if error.code is 'ECONNREFUSED'
         error.message = "Couldn't reach database (connection refused)."
-
+    
     return error
 
 #-----------------------------------------------------------------------------

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -90,12 +90,24 @@ exports.adjustError = (error) ->
                     JSON.stringify serverError.stacktrace or [], null, 2
                 }
             """
+        
+        status = error.statusCode
 
         error = new Error
-        error.message = serverError.message or serverError
+        
+        message = serverError.message
+        if serverError.exception
+            message = "Neo4j " + serverError.exception + ": " + message
+            error.exception = serverError.exception
+            error.name = "Neo4jError"
+            
+        error.message = message
         
         # Attach original error to expose neo4j's error stack and code
         error.originalError = serverError
+        
+        # Expose status code
+        error.statusCode = status
 
     if typeof error isnt 'object'
         error = new Error error

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -84,12 +84,8 @@ exports.adjustError = (error) ->
 
         # also in some cases, the response body is indeed an error object, but
         # it's a Neo4j exception without a message:
-        if serverError?.exception and not serverError.message
-            serverError.message = """
-                Neo4j #{serverError.exception}: #{
-                    JSON.stringify serverError.stacktrace or [], null, 2
-                }
-            """
+        if not serverError.message
+            serverError.message = "(no message)"
         
         status = error.statusCode
 
@@ -97,7 +93,7 @@ exports.adjustError = (error) ->
         
         message = serverError.message
         if serverError.exception
-            message = "Neo4j " + serverError.exception + ": " + message
+            message = "Neo4j #{serverError.exception}: #{message}"
             error.exception = serverError.exception
             error.name = "Neo4jError"
             
@@ -117,7 +113,7 @@ exports.adjustError = (error) ->
     # see: http://stackoverflow.com/a/9254101/132978
     if error.code is 'ECONNREFUSED'
         error.message = "Couldn't reach database (connection refused)."
-    
+
     return error
 
 #-----------------------------------------------------------------------------

--- a/test/cypher._coffee
+++ b/test/cypher._coffee
@@ -173,8 +173,14 @@ user9 = users[9]
                 START notfound=node(999999)
             """, _
         catch err
+            console.log err
+        
             expect(err.originalError).to.be.an 'object'
             expect(err.originalError.message).to.be.an 'string'
             expect(err.originalError.exception).to.be.an 'string'
             expect(err.originalError.stacktrace).to.be.an 'array'
-            expect(err.originalError.message).to.eql err.message
+            expect(err.originalError.message).to.be.an 'string'
+            expect(err.name).to.eql 'Neo4jError'
+            expect(err.exception).to.eql err.originalError.exception
+            expect(err.message).to.match /^Neo4j [A-Za-z]+Exception: /
+            expect(err.statusCode).to.eql 400

--- a/test/cypher._coffee
+++ b/test/cypher._coffee
@@ -173,8 +173,6 @@ user9 = users[9]
                 START notfound=node(999999)
             """, _
         catch err
-            console.log err
-        
             expect(err.originalError).to.be.an 'object'
             expect(err.originalError.message).to.be.an 'string'
             expect(err.originalError.exception).to.be.an 'string'

--- a/test/cypher._coffee
+++ b/test/cypher._coffee
@@ -176,6 +176,5 @@ user9 = users[9]
             expect(err.originalError).to.be.an 'object'
             expect(err.originalError.message).to.be.an 'string'
             expect(err.originalError.exception).to.be.an 'string'
-            expect(err.originalError.fullname).to.be.an 'string'
             expect(err.originalError.stacktrace).to.be.an 'array'
             expect(err.originalError.message).to.eql err.message

--- a/test/cypher._coffee
+++ b/test/cypher._coffee
@@ -166,3 +166,16 @@ user9 = users[9]
         expect(results[0]['path'].relationships).to.have.length 2
         expect(results[0]['path'].relationships[1]).to.be.an 'object'
         # expect(results[0]['path'].relationships[1].type).to.eq 'follows'
+    
+    'neo4j error': (_) ->
+        try
+            results = db.query """
+                START notfound=node(999999)
+            """, _
+        catch err
+            expect(err.originalError).to.be.an 'object'
+            expect(err.originalError.message).to.be.an 'string'
+            expect(err.originalError.exception).to.be.an 'string'
+            expect(err.originalError.fullname).to.be.an 'string'
+            expect(err.originalError.stacktrace).to.be.an 'array'
+            expect(err.originalError.message).to.eql err.message


### PR DESCRIPTION
This way you can use `error.originalError.fullname` to retrieve the status code.
