### PR TITLE
Add ability to pass HTTP headers to Neo4j server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+  - **New:** Pass HTTP headers to Neo4j using
+    `GraphDatabase::query(query, params={}, options={}, callback)` where
+    `options` can contain `headers` object, e.g.
+
+    ```javascript
+    options = {
+      headers: {
+        'X-Request-ID': '14159265359'
+      }
+    }
+    ```
+
   - **New:** this library is now compiled under Streamline's "standalone"
     mode, which means Streamline is no longer a runtime dependency.
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "chai": "~1.8",
     "codo": "~1.5",
     "coffee-script": "~1.7.1",
-    "express": "^4.6.1",
+    "express": "^3.15.0",
     "mocha": "~1.3",
     "streamline": "~0.10 >=0.10.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chai": "~1.8",
     "codo": "~1.5",
     "coffee-script": "~1.7.1",
+    "express": "^4.6.1",
     "mocha": "~1.3",
     "streamline": "~0.10 >=0.10.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,45 +1,53 @@
 {
-    "name": "neo4j",
-    "description": "Neo4j driver (REST API client) for Node.js",
-    "version": "1.1.0",
-    "author": "The Thingdom <info@thethingdom.com>",
-    "contributors": [
-        "Daniel Gasienica <daniel@gasienica.ch>",
-        "Aseem Kishore <aseem.kishore@gmail.com>",
-        "Sergio Haro <sergio.haro.jr@gmail.com>"
-    ],
-    "main": "./lib",
-    "dependencies": {
-        "http-status": "~0.1.0",
-        "request": "~2.27"
-    },
-    "devDependencies": {
-        "chai": "~1.8",
-        "codo": "~1.5",
-        "coffee-script": "~1.7.1",
-        "mocha": "~1.3",
-        "streamline": "~0.10 >=0.10.1"
-    },
-    "engines": {
-        "node": ">= 0.6"
-    },
-    "scripts": {
-        "build": "coffee -m -c lib/ && _coffee -m --standalone -c lib/",
-        "clean": "rm -f lib/*.{js,map}",
-        "codo": "codo && codo --server",
-        "prepublish": "npm run build",
-        "postpublish": "npm run clean",
-        "test": "mocha"
-    },
-    "keywords": [
-        "neo4j", "graph", "database", "driver", "rest", "api", "client"
-    ],
-    "licenses": [{
-        "type": "Apache License, Version 2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }],
-    "repository" : {
-        "type" : "git",
-        "url" : "https://github.com/thingdom/node-neo4j.git"
+  "name": "neo4j",
+  "description": "Neo4j driver (REST API client) for Node.js",
+  "version": "1.1.0",
+  "author": "The Thingdom <info@thethingdom.com>",
+  "contributors": [
+    "Daniel Gasienica <daniel@gasienica.ch>",
+    "Aseem Kishore <aseem.kishore@gmail.com>",
+    "Sergio Haro <sergio.haro.jr@gmail.com>"
+  ],
+  "main": "./lib",
+  "dependencies": {
+    "http-status": "~0.1.0",
+    "request": "~2.27"
+  },
+  "devDependencies": {
+    "chai": "~1.8",
+    "codo": "~1.5",
+    "coffee-script": "~1.7.1",
+    "mocha": "~1.3",
+    "streamline": "~0.10 >=0.10.1"
+  },
+  "engines": {
+    "node": ">= 0.6"
+  },
+  "scripts": {
+    "build": "coffee -m -c lib/ && _coffee -m --standalone -c lib/",
+    "clean": "rm -f lib/*.{js,map}",
+    "codo": "codo && codo --server",
+    "prepublish": "npm run build",
+    "postpublish": "npm run clean",
+    "test": "mocha"
+  },
+  "keywords": [
+    "neo4j",
+    "graph",
+    "database",
+    "driver",
+    "rest",
+    "api",
+    "client"
+  ],
+  "licenses": [
+    {
+      "type": "Apache License, Version 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thingdom/node-neo4j.git"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "chai": "~1.8",
     "codo": "~1.5",
     "coffee-script": "~1.7.1",
-    "express": "^3.15.0",
+    "express": "~3",
     "mocha": "~1.3",
     "streamline": "~0.10 >=0.10.1"
   },

--- a/test/GraphDatabase._coffee
+++ b/test/GraphDatabase._coffee
@@ -1,0 +1,56 @@
+createMockServer = require './mocks/server'
+neo4j = require '..'
+{expect} = require 'chai'
+
+
+describe 'GraphDatabase', ->
+    app = null
+    server = null
+    db = null
+    DB_BASE_URL = null
+
+    beforeEach ->
+        {app, server, port} = createMockServer()
+        DB_BASE_URL = "http://localhost:#{port}"
+        db = new neo4j.GraphDatabase DB_BASE_URL
+
+    afterEach ->
+        server.close()
+
+    describe '#query', ->
+        it 'should forward custom HTTP headers', (_) ->
+            app.post '/db/data/cypher', (req, res) ->
+                {headers} = req
+                res.send
+                    columns: ["root"]
+                    data: [[
+                        paged_traverse: "#{DB_BASE_URL}/db/data/node/0/paged/traverse/{returnType}{?pageSize,leaseTime}"
+                        outgoing_relationships: "#{DB_BASE_URL}/db/data/node/0/relationships/out"
+                        data: {headers}
+                        all_typed_relationships: "#{DB_BASE_URL}/db/data/node/0/relationships/all/{-list|&|types}"
+                        traverse: "#{DB_BASE_URL}/db/data/node/0/traverse/{returnType}"
+                        all_relationships: "#{DB_BASE_URL}/db/data/node/0/relationships/all"
+                        property: "#{DB_BASE_URL}/db/data/node/0/properties/{key}"
+                        self: "#{DB_BASE_URL}/db/data/node/0"
+                        outgoing_typed_relationships: "#{DB_BASE_URL}/db/data/node/0/relationships/out/{-list|&|types}"
+                        properties: "#{DB_BASE_URL}/db/data/node/0/properties"
+                        incoming_relationships: "#{DB_BASE_URL}/db/data/node/0/relationships/in"
+                        incoming_typed_relationships: "#{DB_BASE_URL}/db/data/node/0/relationships/in/{-list|&|types}"
+                        extensions: {}
+                        create_relationship: "#{DB_BASE_URL}/db/data/node/0/relationships"
+                    ]]
+
+            CUSTOM_HEADERS =
+                'X-Request-Id': 'request-id-53'
+                'X-B3-Sampled': 'true'
+
+            [{root}] = db.query """
+                START root=node({id})
+                RETURN root
+            """, {id: 0}, {headers: CUSTOM_HEADERS}, _
+
+            {headers} = root._data.data
+            for name, value of CUSTOM_HEADERS
+                normalizedName = name.toLowerCase()
+                normalizedValue = value.toString()
+                expect(headers[normalizedName]).to.equal normalizedValue

--- a/test/mocks/server._coffee
+++ b/test/mocks/server._coffee
@@ -1,0 +1,37 @@
+express = require 'express'
+
+
+module.exports = ->
+    app = express()
+    server = app.listen()
+    port = server.address().port
+
+    BASE_URL = "http://localhost:#{port}"
+
+    # Root
+    app.get '/', (req, res) ->
+        res.json
+            management: "#{BASE_URL}/db/manage/"
+            data: "#{BASE_URL}/db/data/"
+
+    # Data
+    app.get '/db/data/', (req, res) ->
+        res.json
+            extensions:
+                CypherPlugin:
+                    execute_query: "#{BASE_URL}/db/data/ext/CypherPlugin/graphdb/execute_query"
+
+                GremlinPlugin:
+                    execute_script: "#{BASE_URL}/db/data/ext/GremlinPlugin/graphdb/execute_script"
+
+              node: "#{BASE_URL}/db/data/node"
+              reference_node: "#{BASE_URL}/db/data/node/0"
+              node_index: "#{BASE_URL}/db/data/index/node"
+              relationship_index: "#{BASE_URL}/db/data/index/relationship"
+              extensions_info: "#{BASE_URL}/db/data/ext"
+              relationship_types: "#{BASE_URL}/db/data/relationship/types"
+              batch: "#{BASE_URL}/db/data/batch"
+              cypher: "#{BASE_URL}/db/data/cypher"
+              neo4j_version: "1.9.5"
+
+    {app, server, port}


### PR DESCRIPTION
  - **New:** Pass HTTP headers to Neo4j using
    `GraphDatabase::query(query, params={}, options={}, callback)` where
    `options` can contain `headers` object, e.g.

    ```javascript
    options = {
      headers: {
        'X-Request-ID': '14159265359'
      }
    }
    ```

/cc @aseemk 