### PR TITLE
Added keep-alive agent to improve performance over https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 node_modules/
 npm-debug.log
 
+lib/*.js
+lib/*.map
+
 /doc/
 
 /neo4j-*

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -1,6 +1,7 @@
 lib = require '../package.json'
 request = require 'request'
 KeepAliveAgent = require 'keep-alive-agent'
+keepAlive = new KeepAliveAgent()
 securedKeepAlive = new KeepAliveAgent.Secure()
 URL = require 'url'
 
@@ -19,15 +20,15 @@ USER_AGENT = "node-neo4j/#{lib.version}"
 # - specify that Neo4j should stream its JSON responses.
 # returns a minimal wrapper (HTTP methods only) around request.
 exports.wrapRequest = ({url, proxy}) ->
+    # parse auth info:
+    auth = URL.parse(url).auth
+
     # default request opts where possible (no headers since the whole headers
     # collection will be overridden if any one header is provided):
     req = request.defaults
         json: true
         proxy: proxy
-        agent: securedKeepAlive
-
-    # parse auth info:
-    auth = URL.parse(url).auth
+        agent: if url.protocol is 'https:' then securedKeepAlive else keepAlive
 
     # helper function to modify args to request where defaults not possible:
     modifyArgs = (args) ->

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -1,5 +1,7 @@
 lib = require '../package.json'
 request = require 'request'
+KeepAlive = require 'keep-alive'
+securedKeepAlive = new KeepAlive.Secure()
 URL = require 'url'
 
 #-----------------------------------------------------------------------------
@@ -22,6 +24,7 @@ exports.wrapRequest = ({url, proxy}) ->
     req = request.defaults
         json: true
         proxy: proxy
+        agent: securedKeepAlive
 
     # parse auth info:
     auth = URL.parse(url).auth

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -1,7 +1,7 @@
 lib = require '../package.json'
 request = require 'request'
-KeepAlive = require 'keep-alive'
-securedKeepAlive = new KeepAlive.Secure()
+KeepAliveAgent = require 'keep-alive-agent'
+securedKeepAlive = new KeepAliveAgent.Secure()
 URL = require 'url'
 
 #-----------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "codo": "codo && codo --server",
     "prepublish": "npm run build",
     "postpublish": "npm run clean",
+    "postinstall": "npm run build",
+    "preinstall": "npm run clean",
     "test": "mocha"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,45 +1,54 @@
 {
-    "name": "neo4j",
-    "description": "Neo4j driver (REST API client) for Node.js",
-    "version": "1.1.1",
-    "author": "The Thingdom <info@thethingdom.com>",
-    "contributors": [
-        "Daniel Gasienica <daniel@gasienica.ch>",
-        "Aseem Kishore <aseem.kishore@gmail.com>",
-        "Sergio Haro <sergio.haro.jr@gmail.com>"
-    ],
-    "main": "./lib",
-    "dependencies": {
-        "http-status": "^0.1.0",
-        "request": "^2.27.0"
-    },
-    "devDependencies": {
-        "chai": "^1.8.0",
-        "codo": "^1.5.0",
-        "coffee-script": "1.7.x",
-        "mocha": "^1.3.0",
-        "streamline": "^0.10.16"
-    },
-    "engines": {
-        "node": ">= 0.6"
-    },
-    "scripts": {
-        "build": "coffee -m -c lib/ && _coffee -m --standalone -c lib/",
-        "clean": "rm -f lib/*.{js,map}",
-        "codo": "codo && codo --server",
-        "prepublish": "npm run build",
-        "postpublish": "npm run clean",
-        "test": "mocha"
-    },
-    "keywords": [
-        "neo4j", "graph", "database", "driver", "rest", "api", "client"
-    ],
-    "licenses": [{
-        "type": "Apache License, Version 2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }],
-    "repository" : {
-        "type" : "git",
-        "url" : "https://github.com/thingdom/node-neo4j.git"
+  "name": "neo4j",
+  "description": "Neo4j driver (REST API client) for Node.js",
+  "version": "1.1.1",
+  "author": "The Thingdom <info@thethingdom.com>",
+  "contributors": [
+    "Daniel Gasienica <daniel@gasienica.ch>",
+    "Aseem Kishore <aseem.kishore@gmail.com>",
+    "Sergio Haro <sergio.haro.jr@gmail.com>"
+  ],
+  "main": "./lib",
+  "dependencies": {
+    "http-status": "^0.1.0",
+    "keep-alive": "^0.1.0",
+    "request": "^2.27.0"
+  },
+  "devDependencies": {
+    "chai": "^1.8.0",
+    "codo": "^1.5.0",
+    "coffee-script": "1.7.x",
+    "mocha": "^1.3.0",
+    "streamline": "^0.10.16"
+  },
+  "engines": {
+    "node": ">= 0.6"
+  },
+  "scripts": {
+    "build": "coffee -m -c lib/ && _coffee -m --standalone -c lib/",
+    "clean": "rm -f lib/*.{js,map}",
+    "codo": "codo && codo --server",
+    "prepublish": "npm run build",
+    "postpublish": "npm run clean",
+    "test": "mocha"
+  },
+  "keywords": [
+    "neo4j",
+    "graph",
+    "database",
+    "driver",
+    "rest",
+    "api",
+    "client"
+  ],
+  "licenses": [
+    {
+      "type": "Apache License, Version 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thingdom/node-neo4j.git"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./lib",
   "dependencies": {
     "http-status": "^0.1.0",
-    "keep-alive": "^0.1.0",
+    "keep-alive-agent": "0.0.1",
     "request": "^2.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We were experiencing quite poor response times as node.js doesn't keep the https connections open unless there's a queue of outgoing requests and it therefore had to setup a new https connection on each request. By adding the keep-alive-agent we reduced the response time for a simple request with about 40%.

I couldn't get the tests running (haven't used streamline before..) so I'm not sure if I broke something or not. It's at least working in our environments.
