### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,7 @@
     "keywords": [
         "neo4j", "graph", "database", "driver", "rest", "api", "client"
     ],
-    "licenses": [{
-        "type": "Apache License, Version 2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }],
+    "licenses": "Apache-2.0",
     "repository" : {
         "type" : "git",
         "url" : "https://github.com/thingdom/node-neo4j.git"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "keywords": [
         "neo4j", "graph", "database", "driver", "rest", "api", "client"
     ],
-    "licenses": "Apache-2.0",
+    "license": "Apache-2.0",
     "repository" : {
         "type" : "git",
         "url" : "https://github.com/thingdom/node-neo4j.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license