### PR TITLE
Require callback on commit

### DIFF
--- a/lib-new/Transaction.coffee
+++ b/lib-new/Transaction.coffee
@@ -134,6 +134,9 @@ module.exports = class Transaction
         , @
 
     commit: (cb) ->
+        if not cb
+            throw new Error 'No callback provided!'
+
         @cypher {commit: true}, cb
 
     rollback: (cb) ->

--- a/test-new/transactions._coffee
+++ b/test-new/transactions._coffee
@@ -172,6 +172,10 @@ describe 'Transactions', ->
 
         expect(nodeA.properties.test).to.equal 'committing'
 
+    it 'should fail when committing without a callback', (_) ->
+        tx = DB.beginTransaction()
+        expect(tx.commit).to.throw Error
+
     it 'should support committing before any queries', (_) ->
         tx = DB.beginTransaction()
         expect(tx.state).to.equal tx.STATE_OPEN


### PR DESCRIPTION
Hopefully solves: #170 by ensuring that a callback is passed (rather than making the callback optional)