### PR TITLE
refactor custom Error class to be "Neo4jError". fixes #211

### DIFF
--- a/lib-new/GraphDatabase.coffee
+++ b/lib-new/GraphDatabase.coffee
@@ -1,7 +1,7 @@
 $ = require 'underscore'
 assert = require 'assert'
 Constraint = require './Constraint'
-{Error} = require './errors'
+{Neo4jError} = require './errors'
 Index = require './Index'
 lib = require '../package.json'
 Node = require './Node'
@@ -99,7 +99,7 @@ module.exports = class GraphDatabase
                 # TODO: Do we want to return our own Response object?
                 return cb null, resp
 
-            if err = Error._fromResponse resp
+            if err = Neo4jError._fromResponse resp
                 return cb err
 
             cb null, _transform resp.body
@@ -258,7 +258,7 @@ module.exports = class GraphDatabase
                 # NOTE: This includes our own errors for non-2xx responses.
                 return cb err
 
-            if err = Error._fromResponse resp
+            if err = Neo4jError._fromResponse resp
                 return cb err
 
             _tx?._updateFromResponse resp
@@ -329,7 +329,7 @@ module.exports = class GraphDatabase
                 # TODO: Is it possible to get back more than one error?
                 # If so, is it fine for us to just use the first one?
                 [error] = errors
-                err = Error._fromObject error
+                err = Neo4jError._fromObject error
 
             cb err, results
 
@@ -428,7 +428,7 @@ module.exports = class GraphDatabase
                 return cb null, null
 
             # Translate all other error responses as legitimate errors:
-            if err = Error._fromResponse resp
+            if err = Neo4jError._fromResponse resp
                 return cb err
 
             cb err, if resp.body then Index._fromRaw resp.body
@@ -457,7 +457,7 @@ module.exports = class GraphDatabase
                 return cb null, false
 
             # Translate all other error responses as legitimate errors:
-            if err = Error._fromResponse resp
+            if err = Neo4jError._fromResponse resp
                 return cb err
 
             cb err, true    # Index existed and was dropped
@@ -555,7 +555,7 @@ module.exports = class GraphDatabase
                 return cb null, null
 
             # Translate all other error responses as legitimate errors:
-            if err = Error._fromResponse resp
+            if err = Neo4jError._fromResponse resp
                 return cb err
 
             cb err, if resp.body then Constraint._fromRaw resp.body
@@ -587,7 +587,7 @@ module.exports = class GraphDatabase
                 return cb null, false
 
             # Translate all other error responses as legitimate errors:
-            if err = Error._fromResponse resp
+            if err = Neo4jError._fromResponse resp
                 return cb err
 
             cb err, true    # Constraint existed and was dropped

--- a/lib-new/errors.coffee
+++ b/lib-new/errors.coffee
@@ -2,7 +2,7 @@ $ = require 'underscore'
 assert = require 'assert'
 http = require 'http'
 
-class @Error extends Error
+class @Neo4jError extends Error
 
     constructor: (@message='Unknown error', @neo4j={}) ->
         @name = 'neo4j.' + @constructor.name
@@ -97,8 +97,8 @@ class @Error extends Error
 
     # TODO: Helper to rethrow native/inner errors? Not sure if we need one.
 
-class @ClientError extends @Error
+class @ClientError extends @Neo4jError
 
-class @DatabaseError extends @Error
+class @DatabaseError extends @Neo4jError
 
-class @TransientError extends @Error
+class @TransientError extends @Neo4jError


### PR DESCRIPTION
Resolves conflicts with default JS Error class